### PR TITLE
possible fix for depends issue

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,7 +11,7 @@ set(BUILD_TESTING OFF CACHE BOOL "Disable FCL tests")
 file( MAKE_DIRECTORY "${CMAKE_INSTALL_PREFIX}/include/fcl" )
 
 find_package(PkgConfig)
-pkg_check_modules(PC_CCD ccd)
+pkg_check_modules(PC_CCD libccd-dev)
 
 catkin_package( 
   INCLUDE_DIRS fcl/include ${CMAKE_INSTALL_PREFIX}/include/fcl

--- a/package.xml
+++ b/package.xml
@@ -7,7 +7,7 @@
   <license>BSD</license>
 
   <buildtool_depend>catkin</buildtool_depend>
-  <depend>ccd</depend>
+  <depend>libccd-dev</depend>
   <export>
     <build_type>cmake</build_type>
   </export>


### PR DESCRIPTION
This is a possible fix to the depends issue that breaks the rosdep update. It looks like the correct depends should be on [libccd-dev](https://index.ros.org/d/libccd-dev/)